### PR TITLE
fix to prevent null value of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ It returns an object which can be used to to query a CouchDB or Cloudant databas
 
 ```js
 {
- "fields": null,
  "selector": {
   "owner": {
    "$eq": "glynn"

--- a/index.js
+++ b/index.js
@@ -84,9 +84,7 @@ const parse = function(query) {
   }
 
   // empty cloudant query object
-  var obj = {
-    fields: null
-  };
+  var obj = { };
 
   // parse the SQL into a tree
   const tree = sqlparser.parse(query);
@@ -123,9 +121,7 @@ const parse = function(query) {
       obj.fields.push(simplify(field.field))
       
     }
-  } else {
-    obj.fields = null;
-  }
+  } 
 
   // extract where clauses by recursively walking the tree
   if (tree.where) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqltomango",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Converts SQL statements into CouchDB Mango (Cloudant Query) JSON queries",
   "main": "index.js",
   "scripts": {

--- a/test/parsing.js
+++ b/test/parsing.js
@@ -20,7 +20,7 @@ describe('parsing tests', function() {
 
   it('should handle SELECT *', function() {
     var q = sqltomango("SELECT * FROM mytable");
-    assert.deepEqual(q, { fields: null });
+    assert.deepEqual(q, { });
   });
 
   it('should handle WHERE =', function() {


### PR DESCRIPTION
If "SELECT * FROM mytable WHERE x = '1'"  was supplied, it returned `fields` of `null`. In this case, fields is removed.