### PR TITLE
Add RLIKE -> {$regex:''}

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,10 @@ const selector = function (s, condition) {
       s[simplify(condition.left)] = { $gte: parameterise(condition.right) }
       break
 
+    case 'RLIKE': case 'REGEXP':
+      s[simplify(condition.left)] = { $regex: parameterise(condition.right) }
+      break
+
     case 'IN':
       s[simplify(condition.left)] = { $in: condition.right.value.map(function (v) { return v.value }) }
       break

--- a/sqlparser/lib/lexer.js
+++ b/sqlparser/lib/lexer.js
@@ -204,7 +204,7 @@
 
     SQL_SORT_ORDERS = ['ASC', 'DESC']
 
-    SQL_OPERATORS = ['=', '!=', '>=', '>', '<=', '<>', '<', 'LIKE', 'IS NOT', 'IS']
+    SQL_OPERATORS = ['=', '!=', '>=', '>', '<=', '<>', '<', 'LIKE', 'RLIKE', 'REGEXP', 'IS NOT', 'IS']
 
     SUB_SELECT_OP = ['IN', 'NOT IN', 'ANY', 'ALL', 'SOME']
 


### PR DESCRIPTION
Adds two MySQL style operators: RLIKE/REGEXP which are synonyms and have syntax like `WHERE _id RLIKE '^abc'`. They translate plainly into Mango `{$regex:''}`.